### PR TITLE
Gnome Shell 3.14 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["3.10","3.12"],
+    "shell-version": ["3.10","3.12","3.14"],
     "uuid": "bettervolume@tudmotu.com",
     "name": "Better Volume Indicator",
     "description": "Display volume level while scrolling the indicator, and allow to toggle mute using the scroll/middle button.",


### PR DESCRIPTION
The extension works perfectly with 3.14 too, so 3.14 can be added as supported version.
